### PR TITLE
Fix Transformers benchmark numbers

### DIFF
--- a/bench_pytorch/README.md
+++ b/bench_pytorch/README.md
@@ -7,7 +7,7 @@ The implementation of benchmarking [PyTorch](https://github.com/pytorch/pytorch)
 
 ## 🚀 Running the PyTorch Benchmark.
 
-We can run the PyTorch benchmark for two models: [Llama2](https://huggingface.co/meta-llama/Llama-2-7b) and [Mistral-7B v0.1](https://huggingface.co/mistralai/Mistral-7B-v0.1) Here is how we run benchmark for PyTorch.
+We can run the PyTorch benchmark for two models: [Llama2 7B Chat](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) and [Mistral-7B v0.1 Instruct](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1) Here is how we run benchmark for PyTorch.
 
 ```bash
 ./bench_pytorch/bench.sh \

--- a/docs/llama2.md.template
+++ b/docs/llama2.md.template
@@ -11,7 +11,7 @@
 
 | Engine                                      | float32      | float16        | int8          | int4          |
 |---------------------------------------------|--------------|----------------|---------------|---------------|
-| [transformers (pytorch)](/bench_pytorch/)   | 37.37 ± 0.45 | 34.42 ± 0.45   | 7.07 ± 0.08   | 18.88 ± 0.08  |
+| [transformers (pytorch)](/bench_pytorch/)   | 36.65 ± 0.61 | 34.20 ± 0.51   | 6.91 ± 0.14   | 17.83 ± 0.40  |
 | [AutoAWQ](/bench_autoawq/)                  |      -       |      -         |      -        | 63.59 ± 1.86  |
 | [AutoGPTQ](/bench_autogptq/)                | 34.36 ± 0.51 | 36.63 ± 0.61   |               |               |
 | [DeepSpeed](/bench_deepspeed/)              |              | 84.60 ± 0.25   |               |               |
@@ -24,7 +24,7 @@
 
 | Engine                                      | float32  | float16  | int8     | int4     |
 |---------------------------------------------|----------|----------|----------|----------|
-| [transformers (pytorch)](/bench_pytorch/)   | 29114.76 | 41324.38 | 21384.66 | 12830.38 |
+| [transformers (pytorch)](/bench_pytorch/)   | 29114.76 | 14931.72 | 8596.23  | 5643.44  |
 | [AutoAWQ](/bench_autoawq/)                  |      -   |      -   |      -   | 7149.19  |
 | [AutoGPTQ](/bench_autogptq/)                | 10718.54 | 5706.35  |          |          |
 | [DeepSpeed](/bench_deepspeed/)              |          | 83978.35 |          |          |

--- a/docs/mistral.md.template
+++ b/docs/mistral.md.template
@@ -11,7 +11,7 @@
 
 | Engine                                      | float32      | float16        | int8          | int4          |
 |---------------------------------------------|--------------|----------------|---------------|---------------|
-| [transformers (pytorch)](/bench_pytorch/)   | 39.27 ± 0.54 | 37.57 ± 0.36   | 5.03 ± 0.08   | 19.70 ± 0.30  |
+| [transformers (pytorch)](/bench_pytorch/)   | 39.61 ± 0.65 | 37.05 ± 0.49   | 5.08 ± 0.01   | 19.58 ± 0.38  |
 | [AutoAWQ](/bench_autoawq/)                  |      -       |      -         |      -        | 63.12 ± 2.19  |
 | [AutoGPTQ](/bench_autogptq/)                | 39.11 ± 0.42 | 42.94 ± 0.80   |               |               |
 | [DeepSpeed](/bench_deepspeed/)              |              | 79.88 ± 0.32   |               |               |
@@ -23,7 +23,7 @@
 
 | Engine                                      | float32  | float16  | int8     | int4     |
 |---------------------------------------------|----------|----------|----------|----------|
-| [transformers (pytorch)](/bench_pytorch/)   | 31069.31 | 46030.39 | 23957.86 | 13935.58 |
+| [transformers (pytorch)](/bench_pytorch/)   | 31071.4  | 15976.1  | 10963.91 | 5681.18  |
 | [AutoGPTQ](/bench_autogptq/)                | 13400.80 | 6633.29  |          |          |
 | [AutoAWQ](/bench_autoawq/)                  |      -   |      -   |      -   | 6572.47  |
 | [DeepSpeed](/bench_deepspeed/)              |          | 80104.34 |          |          |


### PR DESCRIPTION
There were some descripencies on the number of memory usage of PyTorch Transformers and some small typo fixes on readme. 

I am merging this PR since, it is a small fix. 

cc: @nsosio 